### PR TITLE
Update link to update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Generated &lt;LANG&gt; parser code for semgrep.
 
-[Instructions for updating this repo](https://github.com/returntocorp/ocaml-tree-sitter/blob/master/doc/release.md)
+[Instructions for updating this repo](https://github.com/returntocorp/ocaml-tree-sitter-semgrep/blob/main/doc/release.md)


### PR DESCRIPTION
The old URI redirects correctly, but a banner appears informing the user of the branch name change.

### Security

- [ ] Change has security implications (if so, ping the security team)
